### PR TITLE
Update/tox config 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,17 +4,20 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: build (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
+    name: build (${{ matrix.codebase }}, Django ${{ matrix.django-version }}, Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9']
+        codebase: ['Supported', 'Dev']
         django-version: ['3.2', 'dev']
+        python-version: ['3.8', '3.9']
+        exclude:
+          - codebase: 'Supported'
+            django-version: 'dev'
 
     services:
-
       mysql:
         image: mysql:latest
         env:
@@ -55,12 +58,12 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/tox.txt
 
-
     - name: Tox tests
       run: |
         tox -v
       env:
         DJANGO: ${{ matrix.django-version }}
+        EDC_CODEBASE: ${{ matrix.codebase }}
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        codebase: ['Supported', 'Dev']
+        codebase: ['Supported', 'Develop']
         django-version: ['3.2', 'dev']
         python-version: ['3.8', '3.9']
         exclude:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 edc>=0.3.21
+git+https://github.com/erikvw/django-import-export.git@get_export_admin_action
+git+https://github.com/yprez/django-logentry-admin.git@master
+git+https://github.com/jazzband/django-defender.git@master

--- a/respond_models/mixins/sf12_model_mixin.py
+++ b/respond_models/mixins/sf12_model_mixin.py
@@ -1,23 +1,23 @@
 from django.db import models
 
-EXCELLENT= "excellent"
-VERY_GOOD= "very_good"
-GOOD="good"
-FAIR="fair"
+EXCELLENT = "excellent"
+VERY_GOOD = "very_good"
+GOOD = "good"
+FAIR = "fair"
 
-x = (
+DESCRIBE_HEALTH_CHOICES = (
     (EXCELLENT, "Excellent"),
     (VERY_GOOD, "Very Good"),
     (GOOD, "Good"),
     (FAIR, "Fair"),
-
 )
+
 
 class Sf12ModelMixin(models.Model):
 
     """Version ?"""
 
-    x = models.CharField(
+    how_describe_health = models.CharField(
         verbose_name="In general, would you say your health is",
-        choices=
+        choices=DESCRIBE_HEALTH_CHOICES,
     )

--- a/runtests.py
+++ b/runtests.py
@@ -40,7 +40,6 @@ DEFAULT_SETTINGS = DefaultTestSettings(
         "django.contrib.staticfiles",
         "django.contrib.sites",
         "django_crypto_fields.apps.AppConfig",
-        "multisite",
         "edc_appointment.apps.AppConfig",
         "edc_action_item.apps.AppConfig",
         "edc_consent.apps.AppConfig",

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,9 @@ python =
 DJANGO =
     3.2: dj32, lint
     dev: djdev
+EDC_CODEBASE =
+    Supported: edcsupported, lint
+    Dev: edcdev
 
 [flake8]
 ignore = E226,E302,E41,F401,W503,W605

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ DJANGO =
     dev: djdev
 EDC_CODEBASE =
     Supported: edcsupported, lint
-    Dev: edcdev
+    Develop: edcdev
 
 [flake8]
 ignore = E226,E302,E41,F401,W503,W605

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{38,39}-dj{32}-{mysql}-edc{supported},
-;    py{38,39}-dj{32,dev}-{mysql}-edc{dev},
+    py{38,39}-dj{32,dev}-{mysql}-edc{dev},
     lint
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     mysql: -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/mysql.txt
 
 commands =
-    pip install -U pip
+    pip --version
     pip freeze
     mysql: coverage run -a runtests.py --database=mysql
     coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/test_utils.txt
     edcsupported: -r requirements.txt
     edcdev: -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/edc.txt
+    edcdev: django-multisite  # temporary until added to requirements.tests/edc.txt
     dj32: Django>=3.2,<3.3
     djdev: https://github.com/django/django/tarball/main
     mysql: -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/mysql.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{38,39}-dj{32}-{mysql}-edc{supported},
-    py{38,39}-dj{32,dev}-{mysql}-edc{dev},
+;    py{38,39}-dj{32,dev}-{mysql}-edc{dev},
     lint
 
 [gh-actions]
@@ -11,7 +11,7 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: dj32
+    3.2: dj32, lint
     dev: djdev
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/test_utils.txt
     edcsupported: -r requirements.txt
     edcdev: -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/edc.txt
-    edcdev: django-multisite  # temporary until added to requirements.tests/edc.txt
+    edcdev: -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/third_party_dev.txt
     dj32: Django>=3.2,<3.3
     djdev: https://github.com/django/django/tarball/main
     mysql: -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/mysql.txt
@@ -34,9 +34,6 @@ deps =
 commands =
     pip install -U pip
     pip freeze
-    edcdev: pip install -U git+https://github.com/erikvw/django-import-export.git@get_export_admin_action
-    edcdev: pip install -U git+https://github.com/yprez/django-logentry-admin.git@master
-    edcdev: pip install -U git+https://github.com/jazzband/django-defender.git@master
     mysql: coverage run -a runtests.py --database=mysql
     coverage report
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ DJANGO =
 ignore = E226,E302,E41,F401,W503,W605
 max-complexity = 10
 max-line-length = 95
-exclude = __init__.py,respond_*/migrations/*,respond_*/tests/*
+exclude = __init__.py,respond_*/migrations/*,.tox/*
 
 [testenv]
 deps =
@@ -42,6 +42,6 @@ commands =
 [testenv:lint]
 deps = -r https://raw.githubusercontent.com/clinicedc/edc/develop/requirements.tests/lint.txt
 commands =
-    isort --profile=black --check --diff respond_africa runtests.py setup.py --skip respond_africa/migrations/
-    black --check --diff respond_africa runtests.py setup.py
-    flake8 respond_africa_edc
+    isort --profile=black --check --diff . --skip 'migrations' --skip '.tox'
+    black --check --diff . --exclude '/migrations/'
+    flake8 .


### PR DESCRIPTION
Updates test enviromnent to:
- run missing 'lint' job in GitHub actions (under Python 3.8, Django3.2 environment)
- fix failing 'edcsupported', and 'djdev' builds
- add all files/dirs (including tests, excluding migrations and .tox dirs) to be linted by isort, Black and Flake8
- split edcsupported and edcdev into separate gh actions builds
